### PR TITLE
Fix np.round_ deprecation and array-to-float conversion errors

### DIFF
--- a/CosinorPy/cosinor.py
+++ b/CosinorPy/cosinor.py
@@ -1633,8 +1633,8 @@ def calculate_statistics(X, Y, Y_fit, n_components, period, lin_comp = False):
     # statistics of GOF according to Cornelissen (eqs (14) - (15))
     # TODO: ali bi bilo potrebno popraviti za lumicycle - ko je več zaporednih meritev v eni časovni točki?
     #X_periodic = (X % period).astype(int)
-    X_periodic = np.round_(X % period,2)                                    
-    
+    X_periodic = np.round(X % period,2)
+
     X_unique = np.unique(X_periodic)
     n_T = len(X_unique)
     

--- a/CosinorPy/cosinor1.py
+++ b/CosinorPy/cosinor1.py
@@ -862,14 +862,14 @@ def test_cosinor_pairs(df, pairs, period = 24, folder = '', prefix='', plot_meas
             'amplitude2': statistics_trans['values'][idx_group_amp],
             'p(amplitude2)':statistics_trans['p-values'][idx_group_amp],
             'd_amplitude': ind_test_amp['value'],
-            'p(d_amplitude)': float(ind_test_amp['p_value']),
+            'p(d_amplitude)': float(np.ravel(ind_test_amp['p_value'])[0]),
             'CI(d_amplitude)': ind_test_amp['conf_int'],
             'acrophase1': statistics_trans['values'][idx_acr],
             'p(acrophase1)':statistics_trans['p-values'][idx_acr],
             'acrophase2': statistics_trans['values'][idx_group_acr],
             'p(acrophase2)':statistics_trans['p-values'][idx_group_acr],
             'd_acrophase': ind_test_acr['value'],
-            'p(d_acrophase)': float(ind_test_acr['p_value']),
+            'p(d_acrophase)': float(np.ravel(ind_test_acr['p_value'])[0]),
             'CI(d_acrophase)': ind_test_acr['conf_int']}
 
         #df_results = df_results.append(d, ignore_index=True)

--- a/CosinorPy/cosinor_nonlin.py
+++ b/CosinorPy/cosinor_nonlin.py
@@ -158,8 +158,8 @@ def calculate_statistics_nonlinear(X, Y, Y_fit, n_params, period):
     except:
         p = 1
     
-    X_periodic = np.round_(X % period,2)                                    
-    
+    X_periodic = np.round(X % period,2)
+
     X_unique = np.unique(X_periodic)
     n_T = len(X_unique)
     


### PR DESCRIPTION
- Replace deprecated np.round_() with np.round() in cosinor.py and cosinor_nonlin.py (np.round_ was removed in NumPy 2.0)
- Wrap p_value in np.ravel()[0] before float() conversion in cosinor1.py to handle cases where p_value is returned as a 1-element array instead of a scalar